### PR TITLE
manipulating github linguist identifier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+datasets/* linguist-vendored


### PR DESCRIPTION
Github identifies stoneforge as a Lasso instead of Python. This is caused by the LAS files in dataset folder. I thing that this change can fix that.